### PR TITLE
Add missing Simd files

### DIFF
--- a/basis-library/mlton/mlton.sig
+++ b/basis-library/mlton/mlton.sig
@@ -47,6 +47,7 @@ signature MLTON =
       structure Rlimit: MLTON_RLIMIT
       structure Rusage: MLTON_RUSAGE
       structure Signal: MLTON_SIGNAL
+      structure Simd: MLTON_SIMD
       structure Syslog: MLTON_SYSLOG
       structure TextIO: MLTON_TEXT_IO
       structure Thread: MLTON_THREAD

--- a/basis-library/mlton/simd.sig
+++ b/basis-library/mlton/simd.sig
@@ -1,0 +1,6 @@
+signature MLTON_SIMD =
+sig
+  type v8i8
+  val create_v8i8: Word8.word -> Word8.word -> Word8.word -> Word8.word -> Word8.word -> Word8.word -> Word8.word -> Word8.word -> v8i8
+  val to_w64: v8i8 -> Word64.word
+end

--- a/basis-library/mlton/simd.sml
+++ b/basis-library/mlton/simd.sml
@@ -1,0 +1,9 @@
+structure MLtonSimd :> MLTON_SIMD =
+struct
+  structure Prim = Primitive.MLton.Simd
+  type v8i8 = Word64.word
+  fun create_v8i8 a b c d e f g h =
+    Prim.create_v8i8 (a, b, c, d, e, f, g, h)
+
+  fun to_w64 (x: v8i8) : Word64.word = x
+end


### PR DESCRIPTION
This now builds and successfully recognizes the `Simd_create_v8i8` prim. On the following small example, compilation succeeds until CCodegen, i.e., the prim is successfully carried through all compiler passes and then crashes at CCodegen which does not know how to generate code for the prim.

```
→ cat foo.mlb
$(SML_LIB)/basis/basis.mlb
$(SML_LIB)/basis/mlton.mlb
foo.sml

→ cat foo.sml
val x = MLton.Simd.create_v8i8 0w0 0w0 0w0 0w0 0w0 0w0 0w0 0w0
val _ = print (Word64.toString (MLton.Simd.to_w64 x) ^ "\n")

→ build/bin/mpl foo.mlb
MLton [mpl] 20250917.022334-g247e156fd-dirty raised: Fail: CCodegen.implementsPrim: Simd_create_v8i8
```