### PR TITLE
fix smlnj-mlton build target

### DIFF
--- a/lib/mlton/basic/sources.cm
+++ b/lib/mlton/basic/sources.cm
@@ -133,6 +133,7 @@ structure Unit
 structure Vector
 structure Word
 structure Word8
+structure Word32
 
 functor Control
 functor Env
@@ -356,3 +357,5 @@ regexp.sml
 
 parse.sig
 parse.sml
+
+word32.sml

--- a/lib/mlton/basic/sources.mlb
+++ b/lib/mlton/basic/sources.mlb
@@ -224,6 +224,8 @@ in
 
       parse.sig
       parse.sml
+
+      word32.sml
    in
       signature APPEND_LIST
       signature ARRAY
@@ -349,6 +351,7 @@ in
       structure Vector
       structure Word
       structure Word8
+      structure Word32
 
       functor Control
       functor Env

--- a/lib/mlton/basic/word32.sml
+++ b/lib/mlton/basic/word32.sml
@@ -1,0 +1,5 @@
+structure Word32 =
+struct
+  open Word32
+  val layout = Layout.str o toString
+end

--- a/lib/mlton/sources.cm
+++ b/lib/mlton/sources.cm
@@ -133,6 +133,7 @@ structure Unit
 structure Vector
 structure Word
 structure Word8
+structure Word32
 
 functor Control
 functor Env

--- a/mlton/atoms/sources.cm
+++ b/mlton/atoms/sources.cm
@@ -104,6 +104,7 @@ var.fun
 func.sig
 label.sig
 spid.sig
+spid.fun
 ffi.sig
 ffi.fun
 cases.sig

--- a/mlton/backend/backend.fun
+++ b/mlton/backend/backend.fun
@@ -230,7 +230,7 @@ fun toMachine (rssa: Rssa.Program.t) =
                      Vector.equals (spwns1, spwns2, Label.equals)
                   fun hash (offset, tokenPolicies, spwns) =
                      Hash.combine (Bytes.hash offset,
-                                   Hash.combine(Hash.vectorMap (tokenPolicies, fn p => p),
+                                   Hash.combine(Hash.vectorMap (tokenPolicies, Word.fromLarge o Word32.toLarge),
                                                 Hash.vectorMap (spwns, Label.hash)))
                in
                   HashTable.new {equals = equals,

--- a/mlton/backend/machine.fun
+++ b/mlton/backend/machine.fun
@@ -736,14 +736,14 @@ structure SporkInfo =
          in
             record [("index", Int.layout index),
                     ("offset", Bytes.layout offset),
-                    ("tokenPolicies", Vector.layout Word.layout tokenPolicies),
+                    ("tokenPolicies", Vector.layout Word32.layout tokenPolicies),
                     ("spwns", Vector.layout Label.layout spwns)]
          end
 
       fun hash (T {index, offset, tokenPolicies, spwns}) =
          Hash.combine (Word.fromInt index,
          Hash.combine (Bytes.hash offset,
-         Hash.combine (Hash.vectorMap (tokenPolicies, fn p => p),
+         Hash.combine (Hash.vectorMap (tokenPolicies, fn p => Word.fromLarge (Word32.toLarge p)),
                        Hash.vectorMap (spwns, Label.hash))))
    end
 


### PR DESCRIPTION
Just a bit of plumbing was missing with Word32. Doing `make smlnj-mlton` now seems to work properly again.